### PR TITLE
Add ratelimit functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,4 +46,5 @@ If you'd like to contribute, take a look at the [Contribution guidelines](docs/C
 * [Tushar Khatri](https://github.com/tusharkhatriofficial/) `(Maintainer)`
 * [Ujjawal Modi](https://github.com/Ujjawal3/)`(contributor)`
 * [Akshay Jadhav](https://github.com/Akshay9607/)`(contributor)`
+* [Abhishek Morla](https://github.com/abhishekmorla/)`(contributor)`
 

--- a/app.js
+++ b/app.js
@@ -6,93 +6,103 @@ const ejs = require("ejs");
 const _ = require("lodash");
 const mongoose = require("mongoose");
 const dotenv = require("dotenv");
+//rate limiting
+const rateLimit = require("express-rate-limit");
 dotenv.config();
 
 const app = express();
 
-app.set('view engine', 'ejs');
+app.set("view engine", "ejs");
 
-app.use(bodyParser.urlencoded({extended: true}));
+app.use(bodyParser.urlencoded({ extended: true }));
 app.use(express.static("public"));
 
 //---------------------------------------------------------------------------------------------------------------------------
 //connecting to the database
-mongoose.connect(process.env.MONGO_URI, {useNewUrlParser: true, useUnifiedTopology: true});
+mongoose.connect(process.env.MONGO_URI, {
+  useNewUrlParser: true,
+  useUnifiedTopology: true,
+});
 
 //creating a schema for the database
 const postSchema = {
   title: String,
   postFeaturedImage: String,
   content: String,
-}
+};
 
 //creating a model for the schema
 const Post = mongoose.model("Post", postSchema);
 //----------------------------------------------------------------------------------------------------------------------------
 
-
+//rate limit
+const rateLimiters = (max) =>
+  rateLimit({
+    windowMs: 24 * 60 * 60 * 1000, // 24 hrs in milliseconds
+    max: max,
+    message: "You have exceeded the 50 requests in 24 hrs limit!",
+    standardHeaders: true,
+    legacyHeaders: false,
+  });
 
 app.get("/", (req, res) => {
-
   Post.find({}, (err, foundPosts) => {
-    if(!err){
+    if (!err) {
       posts = foundPosts;
       res.render("home", {
-        posts: posts
+        posts: posts,
       });
     }
   });
 });
 
+app.get("/register", (req, res) => {
+  res.render("register");
+});
 
-app.get("/register",(req,res)=>{
-  res.render("register")
-})
-
-app.get("/login",(req,res)=>{
-  res.render("login")
-})
+app.get("/login", (req, res) => {
+  res.render("login");
+});
 
 app.get("/about", (req, res) => {
-  res.render("about", {aboutContent: aboutContent});
+  res.render("about", { aboutContent: aboutContent });
 });
 
 app.get("/contact", (req, res) => {
-  res.render("contact", {contactContent: contactContent});
+  res.render("contact", { contactContent: contactContent });
 });
 
 app.get("/compose", (req, res) => {
   res.render("compose");
 });
 
-
-app.post("/compose", (req, res) => {
+app.post("/compose", rateLimiters(25), (req, res) => {
   //creating a new post
   const addPost = new Post({
     title: req.body.postTitle,
     postFeaturedImage: req.body.postFeaturedImage,
-    content: req.body.postBody
+    content: req.body.postBody,
   });
 
-  addPost.save(
-    (err) => {
-      if(!err){
-        res.redirect("/");
-      }
+  addPost.save((err) => {
+    if (!err) {
+      res.redirect("/");
     }
-  );
-
+  });
 });
 
-
 app.get("/posts/:optional", (req, res) => {
-  posts.forEach((element)=>{
+  posts.forEach((element) => {
     var optionalRoute = _.lowerCase(req.params.optional);
-    if(_.lowerCase(element.title) === optionalRoute){
-      res.render("post", {postTitle: element.title, postContent: element.content, postFeaturedImage: element.postFeaturedImage});
-    }else{
+    if (_.lowerCase(element.title) === optionalRoute) {
+      res.render("post", {
+        postTitle: element.title,
+        postContent: element.content,
+        postFeaturedImage: element.postFeaturedImage,
+      });
+    } else {
       console.log("No such route found");
-      }
+    }
   });
 });
 
@@ -100,6 +110,6 @@ app.get("*", (req, res) => {
   res.send("The page you are looking for does not exists!");
 });
 
-app.listen(3000, function() {
+app.listen(3000, function () {
   console.log("Server started on port 3000");
 });


### PR DESCRIPTION
One of the most common use cases for rate limiting is to block brute force attacks. In a brute force attack, a hacker uses automation to send an endless stream of requests to an API, hoping that eventually one may be accepted. Limiting client access will slow down this attack. At the same time, the receiving system should notice the unexpectedly large number of failed requests and generate alerts so that further action may be taken.

In some cases, a user may accidentally cause a brute attack—a bug may cause repeated failed requests, causing the client to keep trying. Rate limiting would help to force a temporary stop and allow for follow-up action.

